### PR TITLE
feat: write parquet with pyarrow and wire main

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -210,4 +210,4 @@ __marimo__/
 2024.csv
 notes.md
 .env
-reports_clean.parquet
+data/clean/*_clean.parquet


### PR DESCRIPTION
This PR completes issue #5. While parts of the implementation landed in earlier commits, this PR finalizes the feature:

- Enforced use of PyArrow in `write_parquet`
- Added flexible naming with `.stem` to generate `<filename>_clean.parquet`
- Added a sanity check: print head of the cleaned Parquet file to stdout